### PR TITLE
feat: add trailing slash in user-url

### DIFF
--- a/dosuri/user/urls.py
+++ b/dosuri/user/urls.py
@@ -14,5 +14,5 @@ urlpatterns = [
     path('v1/token/refresh/', TokenRefreshView.as_view(), name='token_refresh'),
 
     path('v1/auth/', v.Auth.as_view(), name='kakao-auth'),
-    path('v1/users/me', v.UserDetail.as_view(), name='user-detail'),
+    path('v1/users/me/', v.UserDetail.as_view(), name='user-detail'),
 ]


### PR DESCRIPTION
User 모듈의 api 중 `v1/uers/me` 에만 '/' (trailing slash)가 없어서 에러 발생